### PR TITLE
Carriage return chars when using Code on Windows

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,7 +59,7 @@ export class Parser {
     }
 
     private extractModuleImports(filename: string, fileContent: string): string[] {
-        const MODULE_REGEX = new RegExp(/@NgModule\(\{(.|\n)*\}\)/gm); // match @NgModule()
+        const MODULE_REGEX = new RegExp(/@NgModule\(\{(.|\s)*\}\)/gm); // match @NgModule()
 
         let moduleMatch = fileContent.match(MODULE_REGEX);
         if (!moduleMatch) {


### PR DESCRIPTION
Hi, just a small issue I found a couple of days ago. When using Code on Windows to create the module definition object, the editor adds CR+LF, which makes the parser skip the check for `@NgModule` on a file.

The capturing group on the regex would also have been written as `(.|\n|\r\n)*` but I believe that's too much verbose and `\s` covers both cases.

Let me know if you're fine with it and makes sense to you. 