### PR TITLE
Add circular dependency indicator on highlight

### DIFF
--- a/out/index.html
+++ b/out/index.html
@@ -91,8 +91,13 @@
 
         circle.on('mouseover', function(d) {
             path.style('stroke', function(l) {
-                if (d === l.source || d === l.target)
-                    return '#f00'; // highlight link
+                if (d === l.source || d === l.target) {
+                    if (l.circular) {
+                        return '#f00'; // highlight link
+                    } else {
+                        return '#208720';
+                    }
+                }
                 else
                     return '#666';
             });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -40,7 +40,17 @@ export class Parser {
             imports.forEach((moduleImport) => {
                 let externalModule = !modulesWithImports.has(moduleImport);
                 if (moduleImport) {
-                    let d3json = { 'source': classname, 'target': moduleImport, 'externalmodule': externalModule};
+                    let d3json = { 'source': classname, 'target': moduleImport, 'externalmodule': externalModule, 'circular': false};
+
+                    let circularDependency = result.filter(function (jsonItem) {
+                        return jsonItem.source === moduleImport && jsonItem.target === classname;
+                    });
+
+                    if (circularDependency.length > 0) {
+                        d3json.circular = true;
+                        circularDependency[0].circular = true;
+                    }
+
                     result.push(d3json);
                 }
             });


### PR DESCRIPTION
Hi, I have a feature proposal. I'm currently in the middle of a 2.x migration, and wondered if I could identify easily the circular dependencies (which aren't supported by `@NgModule` and it seems they wouldn't be in the near future). 
So, this commit adds a `circular: true` flag on the module report whenever there are two identical paths.
On the graph, I changed the highlight color to greenish and marked the circular paths with the original red.

Example:
```typescript
@NgModule({
    imports: [WidgetModule],
    declarations: [ContactComponent, MessageComponent],
    providers: [ContactService]
})
export class ContactModule {}

@NgModule({
    imports: [ContactModule],
    declarations: [FlexBoxComponent, InboxMessageComponent],
    providers: [DefaultsService]
})
export class WidgetModule {}
```

Hope this makes sense!